### PR TITLE
cron_job table data type and table index

### DIFF
--- a/src/migrations/2013_06_27_144035_create_cronjob_table.php
+++ b/src/migrations/2013_06_27_144035_create_cronjob_table.php
@@ -15,7 +15,8 @@ class CreateCronjobTable extends Migration {
                     $table->string('name');
                     $table->text('return');
                     $table->float('runtime');
-                    $table->integer('cron_manager_id');
+                    $table->integer('cron_manager_id')->unsigned();
+                    $table->index(array('name', 'cron_manager_id'));
                 });
     }
 


### PR DESCRIPTION
The ID inside the cron_manager table is unsigned and the foreign key in cron_job is not, so that joins will not work with an index.

I also added an index, containing the name and cron_manager_id for further queries.