### PR TITLE
Do not use Eloquent class alias

### DIFF
--- a/src/Liebig/Cron/Models/Job.php
+++ b/src/Liebig/Cron/Models/Job.php
@@ -2,7 +2,7 @@
 
 namespace Liebig\Cron\Models;
 
-class Job extends \Eloquent{
+class Job extends \Illuminate\Database\Eloquent\Model{
     
     protected $table = 'cron_job';
     public $timestamps = false;

--- a/src/Liebig/Cron/Models/Manager.php
+++ b/src/Liebig/Cron/Models/Manager.php
@@ -2,7 +2,7 @@
 
 namespace Liebig\Cron\Models;
 
-class Manager extends \Eloquent{
+class Manager extends \Illuminate\Database\Eloquent\Model{
     
     protected $table = 'cron_manager';
     public $timestamps = false;


### PR DESCRIPTION
Using class aliases results in fatal errors if you have aliases disabled. It can be fixed by directly extending the aliased class.