### PR TITLE
Update composer.json for laravel5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "mtdowling/cron-expression": "1.*"
+        "dragonmantank/cron-expression": "2.*"
     }, 
     "require-dev": {
         "illuminate/support": "4.0.x|~5.0"


### PR DESCRIPTION
mtdowling/cron-expressionhas been deprecated and development moved to [https://github.com/dragonmantank/cron-expression],
has some warning: Ambiguous class resolution.